### PR TITLE
Update Gemma 4 blog post with TPU recipe links

### DIFF
--- a/_posts/2026-04-02-gemma4.md
+++ b/_posts/2026-04-02-gemma4.md
@@ -11,6 +11,8 @@ tags:
 
 With the debut of [Gemma 4](https://aistudio.google.com/prompts/new_chat?model=gemma-4-31b-it), vLLM introduces immediate support for Google's most sophisticated open model lineup, spanning multiple hardware backends, with first-ever Day 0 support on [Google TPUs](https://cloud.google.com/tpu), [AMD GPUs](https://docs.vllm.ai/en/stable/getting_started/installation/gpu/), [Intel XPUs](https://docs.vllm.ai/en/stable/getting_started/installation/gpu/#intel-xpu). Purpose-built for advanced reasoning and agentic workflows, Gemma 4 delivers an unprecedented level of intelligence-per-parameter, now accessible to the vLLM community under a commercially permissive [Apache 2.0 license](https://goo.gle/gemma-4-apache-2).
 
+Gemma 4 models are supported on both NVIDIA GPUs and Google Cloud TPUs. TPU support is provided through [vLLM TPU](https://github.com/vllm-project/tpu-inference). For detailed TPU deployment guides, see the [Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4) and [Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/) recipes.
+
 Built from the same world-class research and technology as Gemini 3, the Gemma 4 family includes four versatile sizes designed for diverse hardware environments: Effective 2B (E2B), Effective 4B (E4B), 26B Mixture of Experts (MoE), and 31B Dense.
 
 ![Model Performance VS Size](/assets/figures/gemma4/gemma4-elo-score.png)
@@ -37,6 +39,8 @@ Read the Google blog [here](https://blog.google/innovation-and-ai/technology/dev
 ## Hardware Support
 
 vLLM is optimized to run Gemma 4 across industry-leading hardware backends, enabling developers to achieve frontier-level capabilities with significantly less hardware overhead. vLLM supports seamless deployment on [Nvidia, AMD, Intel GPUs](https://docs.vllm.ai/en/stable/getting_started/installation/gpu/) and [Google TPUs](http://tpu.vllm.ai), ranging from laptop-class cards to datacenter accelerators.
+
+Gemma 4 models are supported on both NVIDIA GPUs and Google Cloud TPUs. TPU support is provided through [vLLM TPU](https://github.com/vllm-project/tpu-inference). For detailed TPU deployment guides, see the [Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4) and [Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/) recipes.
 
 ## Key Capabilities for vLLM Users
 


### PR DESCRIPTION
This PR updates the Gemma 4 blog post with links to the official TPU inference recipes and the vLLM TPU repository.

Changes:

- Added a summary paragraph with links to vLLM TPU, Trillium, and Ironwood recipes.
- Inserted the text block in two locations for maximum visibility:
  1. At the top (immediately following the introduction paragraph).
  2. In the Hardware Support section.

This ensures users looking for TPU deployment guides can easily access the verified recipes directly from the announcement post.