### PR TITLE
Enable future posts and add test post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ description: >
 
 # Build settings
 
+future: true
+
 remote_theme: jekyll/minima@5ce4006d175e6e5278bb63a0aad1a85e3bf2370b
 
 plugins:

--- a/_posts/2026-04-30-test.md
+++ b/_posts/2026-04-30-test.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: "Test Post"
+author: "vLLM Team"
+---
+
+This is a test post.


### PR DESCRIPTION
## Summary
- Set `future: true` in `_config.yml` so Jekyll renders posts whose date is in the future.
- Add `_posts/2026-04-30-test.md` as a test post to verify future-dated rendering.

## Test plan
- [ ] Verify the test post builds and appears on the site preview.
- [ ] Confirm other future-dated posts (if any) now render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)