### PR TITLE
Reframe the diagnostic cosine gap (drop the 5-8x multiplier)

### DIFF
--- a/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
+++ b/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
@@ -74,7 +74,7 @@ There was still useful learning from the encoder chase. The larger SigLIP2-so400
 
 The decisive test was simple: run the same mmes model on the same passport fixture through two paths and compare the embedding behavior.
 
-The PyTorch reference path returned cosine **0.7204** against the relevant passport anchor. The deployed Candle-binding path returned **0.1576** on the same image and conceptual pipeline. That is a 5-8x magnitude gap on the same model and fixture.
+The PyTorch reference path returned cosine **0.7204** against the relevant passport anchor. The deployed Candle-binding path returned **0.1576** on the same image and conceptual pipeline. Same model, same fixture: a strong, correct match collapsing toward noise.
 
 ![](/assets/figures/2026-05-28-vllm-sr-vision-encoder-hardening/diagnostic-gap.png)
 


### PR DESCRIPTION
Small accuracy follow-up to #219 / #221, in the "The reference check that changed the investigation" section.

The post describes the gap between the two cosines (PyTorch reference `0.7204` vs the deployed Candle-binding path `0.1576`) as a "5-8x magnitude gap." Cosine similarity isn't on a ratio scale, so an "Nx" multiplier isn't quite right (and it's the kind of thing a careful reader would flag). This reframes it to characterize the collapse directly, keeping both raw cosines (already shown in the prior two sentences):

- before: "That is a 5-8x magnitude gap on the same model and fixture."
- after: "Same model, same fixture: a strong, correct match collapsing toward noise."

**Requires a matching image regen — cc @Xunzhuo.** The `diagnostic-gap` figure still shows a **"5-8x gap"** starburst in its center, which this prose change now contradicts. To keep the figure and text consistent:

- File: `assets/figures/2026-05-28-vllm-sr-vision-encoder-hardening/diagnostic-gap.png`
- Change: the center **"5-8x gap"** starburst -> **"strong match -> near-noise"**
- Everything else stays the same — the two cosine values (0.7204 / 0.1576) are already in the left/right boxes and remain correct; only the center starburst label changes.

Ideally the prose change and the figure regen land together so the published post never shows the figure and text disagreeing. Happy to coordinate whatever's easiest — I can hold this PR open until you drop the regenerated PNG onto the branch, or you can merge + regen in one pass. Thanks!