### PR TITLE
Add Bowei He to the byline

### DIFF
--- a/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
+++ b/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "From Text to Multimodal Routing: Hardening Vision Signals in vLLM Semantic Router"
-author: "David Shrader, Huamin Chen, Xunzhuo Liu, and the vLLM Semantic Router Team"
+author: "David Shrader, Huamin Chen, Xunzhuo Liu, Bowei He, and the vLLM Semantic Router Team"
 image: /assets/figures/2026-05-28-vllm-sr-vision-encoder-hardening/hero.png
 tags:
   - ecosystem


### PR DESCRIPTION
Adds Bowei He as a co-author on the vision-encoder-hardening post, reflecting his involvement in the broader review and the paper-side work this post connects to. Placed after the last named author, before the vLLM Semantic Router Team line:

`David Shrader, Huamin Chen, Xunzhuo Liu, Bowei He, and the vLLM Semantic Router Team`

cc @Xunzhuo