### PR TITLE
fix: correct vLLM SR blog author names

### DIFF
--- a/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
+++ b/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "From Text to Multimodal Routing: Hardening Vision Signals in vLLM Semantic Router"
-author: "David Shrader, Huamin Chen, Xunzhuo Liu, and the vLLM Semantic Router Team"
+author: "David Shrader, Huamin Chen, Xunzhuo Liu, Bowei He, and the vLLM Semantic Router Team"
 image: /assets/figures/2026-05-28-vllm-sr-vision-encoder-hardening/hero.png
 tags:
   - ecosystem

--- a/_posts/2026-06-02-session-aware-agentic-routing.md
+++ b/_posts/2026-06-02-session-aware-agentic-routing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Session-Aware Agentic Routing: Continuity-Aware Model Selection for Long-Horizon LLM Agents"
-author: "Xunzhuo Liu, Bowei He, Huamin Chen, Haichen Zhang (AMD), Any Luo (AMD), and the vLLM Semantic Router Team"
+author: "Xunzhuo Liu, Bowei He, Huamin Chen, Haichen Zhang (AMD), Andy Luo (AMD), and the vLLM Semantic Router Team"
 image: /assets/figures/2026-06-02-session-aware-agentic-routing/hero-v2.png
 social_image: /assets/figures/2026-06-02-session-aware-agentic-routing/hero-v2.png
 read_time_minutes: 14


### PR DESCRIPTION
## Summary

- Corrects the SAAR blog author name from `Any Luo` to `Andy Luo`.
- Adds `Bowei He` after `Xunzhuo Liu` in the vLLM SR vision encoder hardening blog author list.

## Validation

- `/Users/bitliu/.rbenv/shims/bundle exec jekyll build`