### PR TITLE
Update blogs to include summaries

### DIFF
--- a/_posts/2023-06-20-vllm.md
+++ b/_posts/2023-06-20-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM: Easy, Fast, and Cheap LLM Serving with PagedAttention"
 author: "Woosuk Kwon*, Zhuohan Li*, Siyuan Zhuang, Ying Sheng, Lianmin Zheng, Cody Yu, Joey Gonzalez, Hao Zhang, and Ion Stoica (* Equal Contribution)"
+summary: "What the original vLLM launch announced: PagedAttention for KV cache management, up to 24x throughput over Hugging Face Transformers, and lower-cost high-throughput LLM serving."
 extra: "<br><p align=\"center\"><picture><source media=\"(prefers-color-scheme: dark)\" srcset=\"/assets/logos/vllm-logo-text-dark.png\"><img src=\"/assets/logos/vllm-logo-text-light.png\" width=\"65%\"></picture></p><br>"
 image: /assets/logos/vllm-logo-text-light.png
 tags:

--- a/_posts/2023-11-14-notes-vllm-vs-deepspeed.md
+++ b/_posts/2023-11-14-notes-vllm-vs-deepspeed.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Notes on vLLM v.s. DeepSpeed-FastGen"
 author: "vLLM Team"
+summary: "A performance comparison of vLLM and DeepSpeed-FastGen, explaining when Dynamic SplitFuse helps, where vLLM is faster, and how memory allocation, output length, and workload shape affect throughput."
 image: /assets/figures/notes-vllm-vs-deepspeed/s2.png
 tags:
   - performance

--- a/_posts/2024-07-23-llama31.md
+++ b/_posts/2024-07-23-llama31.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Announcing Llama 3.1 Support in vLLM"
 author: "vLLM Team"
+summary: "How vLLM supports Meta Llama 3.1 models, including 128K context, Llama 3.1 405B serving, chunked prefill, FP8 quantization, tensor and pipeline parallelism, CPU offloading, and early performance results."
 image: /assets/figures/llama31/perf_llama3.png
 tags:
   - model-support

--- a/_posts/2024-07-25-lfai-perf.md
+++ b/_posts/2024-07-25-lfai-perf.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM’s Open Governance and Performance Roadmap"
 author: "vLLM Team"
+summary: "vLLM's open governance and performance roadmap, covering LF AI and Data incubation, public benchmarks, optimized kernels, async scheduling, API frontend overhead, torch.compile, disaggregated prefill, and community research."
 image: /assets/figures/lfai/vllm-lfai-light.png
 tags:
   - community

--- a/_posts/2024-09-05-perf-update.md
+++ b/_posts/2024-09-05-perf-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM v0.6.0: 2.7x Throughput Improvement and 5x Latency Reduction"
 author: "vLLM Team"
+summary: "What changed in vLLM v0.6.0 to improve throughput and latency, including API server isolation, reduced CPU overhead, multi-step scheduling, async execution, and benchmarks against earlier vLLM versions."
 image: /assets/figures/perf-v060/llama8B_comparison.png
 tags:
   - performance

--- a/_posts/2024-10-17-spec-decode.md
+++ b/_posts/2024-10-17-spec-decode.md
@@ -2,6 +2,7 @@
 layout: post
 title: "How Speculative Decoding Boosts vLLM Performance by up to 2.8x"
 author: "vLLM Team"
+summary: "How speculative decoding works in vLLM, covering EAGLE, Medusa, n-gram proposals, draft and target runners, scheduler and memory-manager changes, and continuous batching for lower token latency."
 image: /assets/figures/spec-decode/figure9.png
 tags:
   - speculative-decoding

--- a/_posts/2024-10-23-vllm-serving-amd.md
+++ b/_posts/2024-10-23-vllm-serving-amd.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Serving LLMs on AMD MI300X: Best Practices"
 author: "Guest Post by Embedded LLM and Hot Aisle Inc."
+summary: "Best practices for serving LLMs with vLLM on AMD MI300X, covering ROCm setup, Llama 3.1 70B and 405B benchmarks, chunked prefill, multi-step scheduling, prefix caching, graph capture, and AMD tuning."
 image: /assets/figures/vllm-serving-amd/405b1.png
 tags:
   - hardware

--- a/_posts/2025-01-10-dev-experience.md
+++ b/_posts/2025-01-10-dev-experience.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Installing and Developing vLLM with Ease"
 author: "vLLM Team"
+summary: "How to install and develop vLLM using stable releases, nightly wheels, uv, source builds, Python and C++/CUDA workflows, and version tracking for production deployments."
 image: /assets/logos/vllm-logo-text-light.png
 tags:
   - developer

--- a/_posts/2025-01-10-vllm-2024-wrapped-2025-vision.md
+++ b/_posts/2025-01-10-vllm-2024-wrapped-2025-vision.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM 2024 Retrospective and 2025 Vision"
 author: "vLLM Team"
+summary: "A vLLM 2024 retrospective and 2025 roadmap covering community growth, model and hardware support, production adoption, office hours, ecosystem partnerships, and the path toward universal open-source serving."
 image: /assets/figures/vllm-2024-wrapped-2025-roadmap/model-architecture-serving-usage.png
 tags:
   - community

--- a/_posts/2025-01-14-struct-decode-intro.md
+++ b/_posts/2025-01-14-struct-decode-intro.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Structured Decoding in vLLM: a gentle introduction"
 author: "Guest Post by BentoML and Red Hat"
+summary: "How structured decoding works in vLLM, covering JSON outputs, grammar-guided generation, outlines, XGrammar, TPOT improvements, constrained decoding, and agentic workflow use cases."
 image: /assets/figures/struct-decode-intro/vllm-xgrammar-decode-time-per-output-token.png
 tags:
   - performance

--- a/_posts/2025-01-21-stack-release.md
+++ b/_posts/2025-01-21-stack-release.md
@@ -2,6 +2,7 @@
 layout: post
 title: "High Performance and Easy Deployment of vLLM in K8S with vLLM production-stack"
 author: LMCache Team
+summary: "What vLLM production-stack adds for Kubernetes serving: prefix-aware routing, LMCache-backed KV cache sharing, autoscaling, observability, fault tolerance, and cluster deployment with higher throughput and lower latency."
 image: /assets/figures/stack/stack-thumbnail.png
 tags:
   - large-scale-serving

--- a/_posts/2025-01-27-intro-to-llama-stack-with-vllm.md
+++ b/_posts/2025-01-27-intro-to-llama-stack-with-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Introducing vLLM Inference Provider in Llama Stack"
 author: "Yuan Tang (Red Hat) and Ashwin Bharambe (Meta)"
+summary: "How Llama Stack integrates vLLM as an inference provider through remote and inline providers, enabling OpenAI-compatible vLLM serving for local and Kubernetes generative AI application deployments."
 image: /assets/figures/llama-stack/llama-stack.png
 tags:
   - model-support

--- a/_posts/2025-01-27-v1-alpha-release.md
+++ b/_posts/2025-01-27-v1-alpha-release.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM V1: A Major Upgrade to vLLM's Core Architecture"
 author: "vLLM Team"
+summary: "What changed in vLLM V1: a re-architected engine with a simpler scheduler, near-zero-overhead prefix caching, cleaner tensor parallelism, multiprocessing API server, and default optimizations for higher-throughput serving."
 image: /assets/figures/v1/vLLM_V1_Logo.png
 tags:
   - performance

--- a/_posts/2025-02-17-distributed-inference.md
+++ b/_posts/2025-02-17-distributed-inference.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Distributed Inference with vLLM"
 author: "vLLM Team"
+summary: "A guide to distributed inference in vLLM, covering tensor parallelism, pipeline parallelism, multi-GPU and multi-node serving, KV cache challenges, speculative decoding, communication kernels, and control-plane design."
 image: /assets/logos/vllm-logo-only-light.png
 tags:
   - large-scale-serving

--- a/_posts/2025-02-21-aibrix-release.md
+++ b/_posts/2025-02-21-aibrix-release.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Introducing AIBrix: A Scalable, Cost-Effective Control Plane for vLLM"
 author: "AIBrix Team"
+summary: "What AIBrix adds as a Kubernetes control plane for vLLM: LoRA management, LLM gateway routing, autoscaling, unified runtime, distributed inference, distributed KV cache, heterogeneous serving, and GPU failure detection."
 image: /assets/figures/2025-02-21-aibrix-release/aibrix-architecture-v1.jpeg
 tags:
   - large-scale-serving

--- a/_posts/2025-02-24-ptpc-fp8-rocm.md
+++ b/_posts/2025-02-24-ptpc-fp8-rocm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "PTPC-FP8: Boosting vLLM Performance on AMD ROCm"
 author: "AMD and Embedded LLM"
+summary: "How PTPC-FP8 quantization improves vLLM performance on AMD ROCm by combining per-token activation scaling and per-channel weight scaling for near-BF16 accuracy with FP8 speed."
 image: /assets/figures/ptpc/PTPC-tumbnail.png
 math: true
 tags:

--- a/_posts/2025-04-05-llama4.md
+++ b/_posts/2025-04-05-llama4.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Llama 4 in vLLM"
 author: "The vLLM Team"
+summary: "How vLLM serves Meta Llama 4 Scout and Maverick multimodal MoE models with long-context support, tensor parallel deployment, H100 and H200 guidance, FP8 variants, and performance tips."
 image: /assets/figures/llama4/perf.png
 tags:
   - model-support

--- a/_posts/2025-04-11-transformers-backend.md
+++ b/_posts/2025-04-11-transformers-backend.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Transformers modeling backend integration in vLLM"
 author: "The Hugging Face Team"
+summary: "How vLLM integrates the Hugging Face Transformers modeling backend to serve more model architectures efficiently, including text and vision-language models through model_impl=\"transformers\"."
 image: /assets/figures/transformers-backend/transformers-backend.png
 tags:
   - model-support

--- a/_posts/2025-04-23-openrlhf-vllm.md
+++ b/_posts/2025-04-23-openrlhf-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Accelerating RLHF with vLLM, Best Practice from OpenRLHF"
 author: "The OpenRLHF Team"
+summary: "How OpenRLHF uses vLLM, Ray, ZeRO-3, AutoTP, Ray placement groups, and weight synchronization to accelerate PPO and RLHF sample generation for reasoning models with long chain-of-thought outputs."
 image: /assets/figures/openrlhf-vllm/ray.png
 tags:
   - large-scale-serving

--- a/_posts/2025-05-12-hardware-plugin.md
+++ b/_posts/2025-05-12-hardware-plugin.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Introducing vLLM Hardware Plugin, Best Practice from Ascend NPU"
 author: "The Ascend Team on vLLM"
+summary: "How vLLM hardware plugins decouple backend integrations from core vLLM, using Platform, Executor, Worker, ModelRunner, AttentionBackend, and Communicator hooks to support Ascend NPU and IBM Spyre."
 image: /assets/logos/vllm-logo-only-light.png
 tags:
   - hardware

--- a/_posts/2025-06-30-minimax-m1.md
+++ b/_posts/2025-06-30-minimax-m1.md
@@ -2,6 +2,7 @@
 layout: post
 title: "MiniMax-M1 Hybrid Architecture Meets vLLM: Long Context, Fast Inference"
 author: "MiniMax"
+summary: "How vLLM serves MiniMax-M1's hybrid MoE architecture for long-context inference, covering model deployment, memory management, batched serving, backend optimizations, and Docker-based setup."
 image: /assets/figures/minimax-m1/benchmark.png
 benchmark-img: /assets/figures/minimax-m1/benchmark.png
 moe-img: /assets/figures/minimax-m1/moe.png

--- a/_posts/2025-08-05-gpt-oss.md
+++ b/_posts/2025-08-05-gpt-oss.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Now Supports gpt-oss"
 author: "The vLLM Team"
+summary: "How vLLM supports gpt-oss 20B and 120B on NVIDIA Blackwell, Hopper, and AMD GPUs, with MXFP4 MoE kernels, efficient attention, hybrid KV cache allocation, and built-in tool support."
 image: /assets/logos/vllm-logo-text-light.png
 tags:
   - model-support

--- a/_posts/2025-08-11-cuda-debugging.md
+++ b/_posts/2025-08-11-cuda-debugging.md
@@ -2,6 +2,7 @@
 layout: post
 title: "CUDA Core Dump: An Effective Tool to Debug Memory Access Issues and Beyond"
 author: "Kaichao You"
+summary: "How to debug vLLM CUDA illegal memory access errors with CUDA core dumps, environment variables, cuda-gdb, and GPU state inspection when Python stack traces or CUDA_LAUNCH_BLOCKING are insufficient."
 image: /assets/logos/vllm-logo-text-light.png
 tags:
   - developer

--- a/_posts/2025-08-19-glm45-vllm.md
+++ b/_posts/2025-08-19-glm45-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "GLM-4.5 Meets vLLM: Built for Intelligent Agents"
 author: "Yuxuan Zhang"
+summary: "How to run GLM-4.5 and GLM-4.5V with vLLM for intelligent agents, including hybrid reasoning modes, FP8 and BF16 serving, multimodal support, and NVIDIA Blackwell and Hopper deployment."
 image: /assets/logos/vllm-logo-text-light.png
 tags:
   - model-support

--- a/_posts/2025-08-20-torch-compile.md
+++ b/_posts/2025-08-20-torch-compile.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Introduction to torch.compile and How It Works with vLLM"
 author: "Luka Govedič (Red Hat), Richard Zou (Meta), Addie Stevens (Red Hat), Kaichao You (Tsinghua University), Michael Goin (Red Hat), Saša Zelenović (Red Hat)"
+summary: "How torch.compile works inside vLLM, including TorchDynamo graph capture, TorchInductor code generation, custom compiler passes, graph breaks, model compilation strategy, and performance optimization."
 image: /assets/figures/2025-torch-compile/figure1.png
 tags:
   - performance

--- a/_posts/2025-09-05-anatomy-of-vllm.md
+++ b/_posts/2025-09-05-anatomy-of-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Inside vLLM: Anatomy of a High-Throughput LLM Inference System"
 author: "Aleksa Gordic"
+summary: "How vLLM's inference engine works, covering PagedAttention, continuous batching, prefix caching, speculative decoding, multi-GPU serving, scheduling, and benchmarking for high-throughput LLM workloads."
 image: /assets/figures/2025-vllm-anatomy/engine_constructor.png
 tags:
   - large-scale-serving

--- a/_posts/2025-09-05-beyond-text-generation.md
+++ b/_posts/2025-09-05-beyond-text-generation.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Serving Geospatial, Vision, and Beyond: Enabling Multimodal Output Processing in vLLM"
 author: Christian Pinto (IBM Research Europe - Dublin), Michele Gazzetti (IBM Research Europe - Dublin), Michael Johnston (IBM Research Europe - Dublin), Maximilien Philippe Marie de Bayser (IBM Research - Brazil)
+summary: "How vLLM expands beyond text generation to serve geospatial, vision, and other non-autoregressive models with pooling-model support, TerraTorch integration, raw tensor handling, and flexible IO processors."
 image: /assets/figures/beyond-text/io-plugins-flow.png
 tags:
   - multimodal

--- a/_posts/2025-09-11-qwen3-next.md
+++ b/_posts/2025-09-11-qwen3-next.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Now Supports Qwen3-Next: Hybrid Architecture with Extreme Efficiency"
 author: "The vLLM Team"
+summary: "How vLLM supports Qwen3-Next with hybrid attention, Gated DeltaNet, full attention, high-sparsity MoE, multi-token prediction, hybrid KV cache management, Triton kernels, and CUDA graphs."
 image: /assets/figures/qwen3-next/qwen.png
 tags:
   - model-support

--- a/_posts/2025-09-11-semantic-router.md
+++ b/_posts/2025-09-11-semantic-router.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Semantic Router: Next Phase in LLM inference"
 author: "vLLM Semantic Router Team"
+summary: "How vLLM Semantic Router routes requests by intent, covering semantic classification, smart reasoning-path selection, Rust and Candle execution, and Kubernetes Envoy integration for efficient inference."
 image: /assets/figures/semantic-router/architecture.png
 tags:
   - ecosystem

--- a/_posts/2025-09-16-vllm-meetup.md
+++ b/_posts/2025-09-16-vllm-meetup.md
@@ -2,6 +2,7 @@
 layout: post
 title: "The First vLLM Meetup in Korea"
 author: "vLLM Team"
+summary: "What the first vLLM Korea meetup covered: community adoption, llm-d, TPU integration, contribution workflows, hardware plugin architecture, Rebellions NPU work, and production inference lessons."
 image: /assets/figures/vllm-meetup/image-3.png
 tags:
   - community

--- a/_posts/2025-09-29-deepseek-v3-2.md
+++ b/_posts/2025-09-29-deepseek-v3-2.md
@@ -2,6 +2,7 @@
 layout: post
 title: "DeepSeek-V3.2-Exp in vLLM: Fine-Grained Sparse Attention in Action"
 author: "vLLM Team"
+summary: "How vLLM supports DeepSeek-V3.2-Exp with DeepSeek Sparse Attention, lightning indexer caches, separate prefill and decode paths, FlashMLA sparse attention, DeepGEMM kernels, and Blackwell deployment."
 image: /assets/figures/deepseek-v3-2/dsa-explained.png
 tags:
   - model-support

--- a/_posts/2025-10-09-blackwell-inferencemax.md
+++ b/_posts/2025-10-09-blackwell-inferencemax.md
@@ -2,6 +2,7 @@
 layout: post
 title: "SemiAnalysis InferenceMAX: vLLM and NVIDIA Accelerate Blackwell Inference"
 author: "vLLM Team"
+summary: "How vLLM and NVIDIA optimize Blackwell inference for SemiAnalysis InferenceMAX, improving gpt-oss 120B and Llama 3.3 70B throughput with FP4 kernels, scheduling work, and Pareto-frontier benchmarking."
 image: /assets/figures/blackwell-inferencemax/gpt-oss-120b-1k-1k.png
 tags:
   - hardware

--- a/_posts/2025-10-16-vllm-tpu.md
+++ b/_posts/2025-10-16-vllm-tpu.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM TPU: A New Unified Backend Supporting PyTorch and JAX on TPU"
 author: "Google Team"
+summary: "How the redesigned vLLM TPU backend uses tpu-inference, JAX-to-XLA lowering, Torchax, ragged paged attention, and unified PyTorch and JAX support to improve TPU performance and model coverage."
 image: /assets/figures/vllm-tpu/vllm-tpu.png
 tags:
   - hardware

--- a/_posts/2025-10-22-agent-lightning.md
+++ b/_posts/2025-10-22-agent-lightning.md
@@ -2,6 +2,7 @@
 layout: post
 title: "No More Retokenization Drift: Returning Token IDs via the OpenAI Compatible API Matters in Agent RL"
 author: "The Agent Lightning (AGL) Team"
+summary: "How vLLM's OpenAI-compatible API can return prompt and response token IDs to prevent retokenization drift in agent reinforcement learning, preserving exact sampled sequences for stable on-policy updates."
 image: /assets/figures/agent-lightning/1_rewards.png
 ---
 

--- a/_posts/2025-10-23-now_serving_nvidia_nemotron_with_vllm.md
+++ b/_posts/2025-10-23-now_serving_nvidia_nemotron_with_vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Now Serving NVIDIA Nemotron with vLLM"
 author: "NVIDIA Nemotron Team"
+summary: "How vLLM serves NVIDIA Nemotron Nano 2 for agentic reasoning, including hybrid Transformer-Mamba architecture, thinking budget control, open weights and data, throughput benefits, and deployment commands."
 image: /assets/figures/2025-vllm-nvidia-nemotron/figure1.png
 tags:
   - model-support

--- a/_posts/2025-10-26-sleep-mode.md
+++ b/_posts/2025-10-26-sleep-mode.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Zero-Reload Model Switching with vLLM Sleep Mode"
 author: "Embedded LLM"
+summary: "How vLLM Sleep Mode enables fast model switching by hibernating weights to CPU RAM or discarding them while preserving process state, CUDA graphs, allocators, and kernel warmup to avoid full reloads."
 image: /assets/figures/2025-vllm-sleep-mode/sleepmode.png
 thumbnail-img: /assets/figures/2025-vllm-sleep-mode/sleepmode.png
 share-img: /assets/figures/2025-vllm-sleep-mode/sleepmode.png

--- a/_posts/2025-10-27-semantic-router-modular.md
+++ b/_posts/2025-10-27-semantic-router-modular.md
@@ -2,6 +2,7 @@
 layout: post
 title: "From Monolithic to Modular: Scaling Semantic Routing with Extensible LoRA"
 author: "Ivar Flakstad (Hugging Face), OneZero-Y, Huamin Chen (Red Hat), Xunzhuo Liu (Tencent)"
+summary: "How vLLM Semantic Router refactors its Rust classification layer with modular model support, Qwen3-Embedding, EmbeddingGemma, LoRA-based multi-task classification, and concurrent routing execution."
 image: /assets/figures/semantic-router/modular.png
 tags:
   - ecosystem

--- a/_posts/2025-10-28-Kimi-K2-Accuracy.md
+++ b/_posts/2025-10-28-Kimi-K2-Accuracy.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chasing 100% Accuracy: A Deep Dive into Debugging Kimi K2's Tool-Calling on vLLM"
 author: "Linian Wang (Peking University)"
+summary: "How vLLM debugged Kimi K2 tool-calling accuracy, covering chat-template compatibility, add_generation_prompt handling, schema validation failures, benchmark fixes, and tool-use reliability."
 image: /assets/figures/kimi-k2-accuracy/k2-vendor-verifier.jpeg
 tags:
   - model-support

--- a/_posts/2025-10-31-run-multimodal-reasoning-agents-nvidia-nemotron.md
+++ b/_posts/2025-10-31-run-multimodal-reasoning-agents-nvidia-nemotron.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Run Multimodal Reasoning Agents with NVIDIA Nemotron on vLLM"
 author: "NVIDIA Nemotron Team"
+summary: "How to serve NVIDIA Nemotron Nano 2 VL with vLLM for multimodal reasoning agents, including video understanding, document intelligence, Efficient Video Sampling, 128K context, and OpenAI-compatible deployment."
 image: /assets/figures/2025-multimodal-nvidia-nemotron/figure1.png
 tags:
   - model-support

--- a/_posts/2025-11-10-bitwise-consistent-train-inference.md
+++ b/_posts/2025-11-10-bitwise-consistent-train-inference.md
@@ -2,6 +2,7 @@
 layout: post
 title: "No More Train-Inference Mismatch: Bitwise Consistent On-Policy Reinforcement Learning with vLLM and TorchTitan"
 author: "vLLM and TorchTitan Teams"
+summary: "How vLLM and TorchTitan demonstrate bitwise consistent on-policy RL by matching training and inference numerics, using batch-invariant kernels to reduce train-inference mismatch and stabilize reinforcement learning."
 image: /assets/figures/2025-11-10-bitwise-exact-rl/reward-comparison.png
 tags:
   - performance

--- a/_posts/2025-11-11-intel-arc-pro-b.md
+++ b/_posts/2025-11-11-intel-arc-pro-b.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Fast and Affordable LLMs serving on Intel Arc Pro B-Series GPUs with vLLM"
 author: "Intel vLLM Team"
+summary: "How vLLM serves LLMs on Intel Arc Pro B-Series GPUs with MoE optimizations, persistent kernels, multi-GPU scaling, LoRA, speculative decoding, structured outputs, and mixed-precision recipes."
 image: /assets/figures/2025-vllm-on-intel-arc/perf-figure1.png
 tags:
   - hardware

--- a/_posts/2025-11-13-shm-ipc-cache.md
+++ b/_posts/2025-11-13-shm-ipc-cache.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Shared Memory IPC Caching: Accelerating Data Transfer in LLM Inference Systems"
 author: "Donglu Wang (Cohere)"
+summary: "How shared memory IPC caching in vLLM reduces redundant data transfers for multimodal and multi-process inference, improving prefill throughput and TTFT by sharing large inputs across coordinator and worker processes."
 image: /assets/figures/2025-shm-ipc-cache/processes1.png
 tags:
   - performance

--- a/_posts/2025-11-19-docker-model-runner-vllm.md
+++ b/_posts/2025-11-19-docker-model-runner-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Docker Model Runner Integrates vLLM for High-Throughput Inferencing"
 author: "Docker Team"
+summary: "How Docker Model Runner integrates vLLM as an inference backend, letting developers run safetensors models with high-throughput serving, PagedAttention, streaming, and OpenAI-compatible APIs from Docker workflows."
 image: /assets/logos/vllm-logo-text-light.png
 ---
 

--- a/_posts/2025-11-19-signal-decision.md
+++ b/_posts/2025-11-19-signal-decision.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Signal-Decision Driven Architecture: Reshaping Semantic Routing at Scale"
 author: "vLLM Semantic Router Team"
+summary: "How vLLM Semantic Router replaces fixed domain classification with signal-decision architecture, combining multi-dimensional signals, AND/OR decision logic, model selection, and plugin orchestration for production routing."
 image: /assets/figures/semantic-router/signal-0.png
 tags:
   - ecosystem

--- a/_posts/2025-11-20-vllm-plugin-system.md
+++ b/_posts/2025-11-20-vllm-plugin-system.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Building Clean, Maintainable vLLM Modifications Using the Plugin System"
 author: "Dhruvil Bhatt (AWS SageMaker)"
+summary: "How the vLLM plugin system helps teams customize scheduling, KV-cache behavior, hardware integrations, and model execution without long-lived forks, monkey patches, or brittle internal modifications."
 image: /assets/figures/2025-11-20-vllm-plugin-system/vllm-plugin-system-arch.png
 tags:
   - developer

--- a/_posts/2025-11-22-ray-symmetric-run.md
+++ b/_posts/2025-11-22-ray-symmetric-run.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Streamlined multi-node serving with Ray symmetric-run"
 author: "Richard Liaw (Anyscale/Ray), Kaichao You (vLLM)"
+summary: "How Ray symmetric-run simplifies multi-node vLLM serving by launching the same entrypoint on every Ray cluster node, matching HPC and parallel SSH workflows for distributed model deployments."
 image: /assets/figures/2025-11-25-ray-symmetric-run/symmetric-run.png
 tags:
   - large-scale-serving

--- a/_posts/2025-11-30-vllm-omni.md
+++ b/_posts/2025-11-30-vllm-omni.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Announcing vLLM-Omni: Easy, Fast, and Cheap Omni-Modality Model Serving"
 author: "vLLM-Omni Team"
+summary: "What vLLM-Omni adds to the vLLM ecosystem: omni-modality serving for text, image, video, and audio, diffusion and non-autoregressive generation support, disaggregated stages, OpenAI-compatible APIs, and pipelined execution."
 image: /assets/figures/2025-11-30-vllm-omni/vllm-omni-logo-text-dark.png
 tags:
   - multimodal

--- a/_posts/2025-12-03-improved-cuda-debugging.md
+++ b/_posts/2025-12-03-improved-cuda-debugging.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Tracing Hanging and Complicated GPU Kernels Down To The Source Code"
 author: "Kaichao You (vLLM)"
+summary: "How vLLM developers debug hanging and complex CUDA kernels by triggering GPU core dumps, identifying stuck kernels, and mapping failures back to source code lines for faster kernel debugging."
 image: /assets/figures/2025-12-03-improved-cuda-debugging/cuda-debugging.png
 tags:
   - developer

--- a/_posts/2025-12-09-intel-autoround-llmc.md
+++ b/_posts/2025-12-09-intel-autoround-llmc.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Advancing Low‑Bit Quantization for LLMs: AutoRound x LLM Compressor"
 author: "Intel Neural Compressor Team, Red Hat AI Model Optimization Team"
+summary: "How Intel AutoRound integrates with LLM Compressor to produce low-bit quantized checkpoints for vLLM, using tuning-based PTQ, W4A16 and related formats, compressed-tensors compatibility, and lightweight calibration."
 image: /assets/figures/2025-12-09-intel-autoround-llmc/autoround-llmc.png
 tags:
   - quantization

--- a/_posts/2025-12-13-speculators-v030.md
+++ b/_posts/2025-12-13-speculators-v030.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Diving into speculative decoding training support for vLLM with Speculators v0.3.0"
 author: "Fynn Schmitt-Ulms, Helen Zhao, Rahul Tuli and Dipika Sikka (Red Hat AI Model Optimization Team)"
+summary: "How Speculators v0.3.0 supports end-to-end Eagle3 draft model training for vLLM, including hidden-state data generation, MoE and non-MoE verifiers, offline workflows, and seamless speculative decoding serving."
 image: /assets/figures/2025-12-13-speculators-v030/cropped_workflow.png
 tags:
   - speculative-decoding

--- a/_posts/2025-12-13-vllm-router-release.md
+++ b/_posts/2025-12-13-vllm-router-release.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Router: A High-Performance and Prefill/Decode Aware Load Balancer for Large-scale Serving"
 author: "vLLM Team"
+summary: "What vLLM Router provides for large-scale serving: Rust-based state-aware load balancing, KV-cache affinity, prefill/decode disaggregation orchestration, Kubernetes discovery, retries, circuit breakers, and Prometheus metrics."
 image: /assets/figures/vllm-router/vllm-router.png
 tags:
   - large-scale-serving

--- a/_posts/2025-12-14-halugate.md
+++ b/_posts/2025-12-14-halugate.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Token-Level Truth: Real-Time Hallucination Detection for Production LLMs"
 author: "vLLM Semantic Router Team"
+summary: "How HaluGate adds token-level hallucination detection to vLLM Semantic Router by verifying assistant claims against tool outputs and grounding context in real time without LLM-as-judge overhead."
 image: /assets/figures/semantic-router/halugate-0.png
 tags:
   - ecosystem

--- a/_posts/2025-12-15-run-nvidia-nemotron-3-nano.md
+++ b/_posts/2025-12-15-run-nvidia-nemotron-3-nano.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Run Highly Efficient and Accurate AI Agents with NVIDIA Nemotron 3 Nano on vLLM"
 author: "NVIDIA Nemotron Team"
+summary: "How to serve NVIDIA Nemotron 3 Nano with vLLM for efficient agentic AI, including BF16, FP8, and NVFP4 checkpoints, 1M-token context, hybrid MoE architecture, Thinking Budget, supported GPUs, and OpenAI-compatible deployment."
 image: /assets/figures/2025-vllm-nvidia-nemotron/figure1.png
 tags:
   - model-support

--- a/_posts/2025-12-15-vllm-epd.md
+++ b/_posts/2025-12-15-vllm-epd.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Encoder Disaggregation for Scalable Multimodal Model Serving"
 author: "Multimodality Workstream @ vLLM"
+summary: "How vLLM EPD separates visual encoders from text prefill and decode, covering LMM serving, GPU resource scaling, multimodal interference, and pipelined execution."
 image: /assets/figures/2025-12-15-epd/image.png
 tags:
   - multimodal

--- a/_posts/2025-12-16-vllm-sr-amd.md
+++ b/_posts/2025-12-16-vllm-sr-amd.md
@@ -2,6 +2,7 @@
 layout: post
 title: "AMD × vLLM Semantic Router: Building the System Intelligence Together"
 author: "The AMD and vLLM Semantic Router Team"
+summary: "How AMD and vLLM Semantic Router build GPU-accelerated Mixture-of-Models routing with signals, semantic caching, response storage, PII, jailbreak, and hallucination guardrails."
 image: /assets/figures/semantic-router/amd-0.png
 tags:
   - hardware

--- a/_posts/2025-12-17-large-scale-serving.md
+++ b/_posts/2025-12-17-large-scale-serving.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Large Scale Serving: DeepSeek @ 2.2k tok/s/H200 with Wide-EP"
 author: "vLLM Team"
+summary: "How vLLM reaches 2.2k tokens per second per H200 for DeepSeek-style MoE serving with Wide-EP, async scheduling, dual-batch overlap, disaggregated serving, CUDA graphs, DeepGEMM, and expert load balancing."
 image: /assets/figures/2025-12-17-large-scale-serving/prefill_throughput.png
 tags:
   - large-scale-serving

--- a/_posts/2025-12-19-vllm-omni-diffusion-cache-acceleration.md
+++ b/_posts/2025-12-19-vllm-omni-diffusion-cache-acceleration.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM-Omni Diffusion Cache Acceleration"
 author: "vLLM-Omni Team"
+summary: "How vLLM-Omni speeds up diffusion model inference with Cache-DiT and TeaCache, reusing intermediate computations across timesteps to deliver 1.5x to 2x image generation speedups with minimal quality loss."
 image: /assets/figures/2025-12-19-vllm-omni-diffusion-cache-acceleration/qwen_bear_base.png
 tags:
   - multimodal

--- a/_posts/2025-12-27-vllm-ai-website.md
+++ b/_posts/2025-12-27-vllm-ai-website.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Announcing vllm.ai Website and Some Community Updates"
 author: "vLLM Team"
+summary: "What changed on the new vllm.ai website for vLLM users: installation guidance, events pages, Slack and X community channels, vLLM Daily updates, and a clearer project/community split."
 image: /assets/figures/2025-vllm-website/homepage.jpg
 tags:
   - community

--- a/_posts/2026-01-02-introducing-vllm-playground.md
+++ b/_posts/2026-01-02-introducing-vllm-playground.md
@@ -3,6 +3,7 @@ layout: post
 title: "Introducing vLLM Playground: A Modern Web Interface for Managing and Interacting with vLLM Servers"
 date: 2026-01-02
 author: micytao
+summary: "How vLLM Playground provides a web UI for starting, configuring, testing, and monitoring vLLM servers across local macOS, Linux GPU or CPU, Kubernetes, and OpenShift environments."
 categories: [community, tools]
 image: /assets/figures/vllm-playground/vllm-playground-newUI.png
 tags:

--- a/_posts/2026-01-05-vllm-sr-iris.md
+++ b/_posts/2026-01-05-vllm-sr-iris.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Semantic Router v0.1 Iris: The First Major Release"
 author: "vLLM Semantic Router Team"
+summary: "What vLLM Semantic Router v0.1 Iris introduces: signal-decision plugin architecture, model selection, safety filtering, semantic caching, hallucination detection, LoRA-based routing models, and production-ready MoM routing."
 image: /assets/figures/semantic-router/iris-0.png
 tags:
   - ecosystem

--- a/_posts/2026-01-08-kv-offloading-connector.md
+++ b/_posts/2026-01-08-kv-offloading-connector.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Inside vLLM’s New KV Offloading Connector: Smarter Memory Transfer for Maximizing Inference Throughput"
 author: "Or Ozeri, Danny Harnik (vLLM Team at IBM Research)"
+summary: "How vLLM's asynchronous KV offloading connector stores KV cache in CPU memory to reduce recomputation, improve throughput under memory pressure, and support pluggable offload backends."
 image: /assets/figures/2026-01-08-kv-offloading-connector/figure2.png
 tags:
   - performance

--- a/_posts/2026-01-23-mom-on-amd-gpu.md
+++ b/_posts/2026-01-23-mom-on-amd-gpu.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Building Mixture-of-Models on AMD GPUs with vLLM-SR"
 author: "The AMD and vLLM Semantic Router Team"
+summary: "How vLLM Semantic Router builds a Mixture-of-Models system on AMD MI300X and MI355X GPUs, routing across specialized models with signals, decisions, safety checks, semantic caching, and live MoM deployment."
 image: /assets/figures/semantic-router/mom-0.png
 tags:
   - hardware

--- a/_posts/2026-01-31-streaming-realtime.md
+++ b/_posts/2026-01-31-streaming-realtime.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Streaming Requests & Realtime API in vLLM"
 author: "Meta, Mistral AI as well as the vLLM team"
+summary: "How vLLM supports streamable inputs and a Realtime WebSocket API for audio, video, robotics, and low-latency applications that need incremental input processing instead of complete prompts."
 image: /assets/figures/2026-01-31-streaming-realtime/streaming-realtime.png
 math: true
 tags:

--- a/_posts/2026-02-01-gpt-oss-optimizations.md
+++ b/_posts/2026-02-01-gpt-oss-optimizations.md
@@ -2,6 +2,7 @@
 layout: post
 title: "GPT-OSS Performance Optimizations on NVIDIA Blackwell: Pushing the Pareto Frontier"
 author: "The vLLM and NVIDIA team"
+summary: "How vLLM and NVIDIA optimized GPT-OSS on Blackwell with FlashInfer, torch.compile fusion, FP8 KV cache, async scheduling, stream interval tuning, and deployment recipes that improve throughput and interactivity."
 image: /assets/figures/blackwell-inferencemax/gpt-oss-120b-8k-1k-nov-jan.png
 tags:
   - performance

--- a/_posts/2026-02-03-dsr1-gb200-part1.md
+++ b/_posts/2026-02-03-dsr1-gb200-part1.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Driving vLLM WideEP and Large-Scale Serving Toward Maturity on Blackwell (Part I)"
 author: "Meta and NVIDIA Team"
+summary: "How vLLM improves WideEP and large-scale DeepSeek-style MoE serving on NVIDIA GB200 with NVFP4 and FP8 kernels, fusion, prefill/decode disaggregation, weight offloading, and reduced chunking overhead."
 image: /assets/figures/2026-02-03-dsr1-gb200/topline_comparison.png
 redirect_from:
     - /2026/02/03/dsr1-gb200.html

--- a/_posts/2026-02-13-gb300-deepseek.md
+++ b/_posts/2026-02-13-gb300-deepseek.md
@@ -2,6 +2,7 @@
 layout: post
 title: "DeepSeek-V3.2 on GB300: Performance Breakthrough"
 author: "The DaoCloud and vLLM team"
+summary: "What DeepSeek-V3.2 and DeepSeek-R1 benchmark results show on NVIDIA GB300 with vLLM, covering NVFP4 quantization, TP and EP deployment, throughput, and reproducible setup details."
 image: /assets/figures/2026-02-13-deepseek/dsr1-h200-b300-gb300-throughput.png
 tags:
   - hardware

--- a/_posts/2026-02-26-multi-lora.md
+++ b/_posts/2026-02-26-multi-lora.md
@@ -2,6 +2,7 @@
 layout: post  
 title: "Efficiently serve dozens of fine-tuned models with vLLM on Amazon SageMaker AI and Amazon Bedrock"  
 author: "Danielle Maddix Robinson, Florian Saupe, George Novack, Haipeng Li, Mani Kumar Adari, Xiang Song, Yu Gong (AWS AI Team)"
+summary: "How vLLM serves many fine-tuned MoE and dense models with Multi-LoRA, including fused MoE LoRA kernels, Triton compiler fixes, Split-K and CTA swizzling optimizations, and SageMaker AI and Bedrock tuning."
 image: /assets/figures/2026-multilora/otps.png
 tags:
   - performance

--- a/_posts/2026-02-27-rocm-attention-backend.md
+++ b/_posts/2026-02-27-rocm-attention-backend.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Beyond Porting: How vLLM Orchestrates High-Performance Inference on AMD ROCm"
 author: "AMD and Embedded LLM"
+summary: "How vLLM orchestrates high-performance inference on AMD ROCm with multiple attention backends, workload-aware prefill, extend, and decode routing, AITER primitives, MLA support, and MI300X-class benchmarks."
 image: /assets/figures/2026-02-27-rocm-attention-backend/ROCm-Attention-rocm_aiter_fa.png
 math: true
 tags:

--- a/_posts/2026-03-04-vllm-triton-backend-deep-dive.md
+++ b/_posts/2026-03-04-vllm-triton-backend-deep-dive.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Triton Attention Backend Deep Dive"
 author: "vLLM Team at IBM Research"
+summary: "A technical walkthrough of the vLLM Triton attention backend, covering performance-portable paged attention kernels, backend selection, autotuning, CUDA graph behavior, benchmarks, and NVIDIA, AMD, and Intel support."
 image: /assets/figures/2026-03-04-vllm-triton-backend/image1.png
 math: true
 tags:

--- a/_posts/2026-03-10-v0.2-vllm-sr-athena-release.md
+++ b/_posts/2026-03-10-v0.2-vllm-sr-athena-release.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Semantic Router v0.2 Athena: ClawOS, Model Refresh, and the System Brain"
 author: "vLLM Semantic Router Team"
+summary: "What vLLM Semantic Router v0.2 Athena adds: refreshed multilingual and multimodal routing models, ONNX and ROCm acceleration, safety and memory signals, long-context handling, and ClawOS orchestration."
 image: /assets/figures/semantic-router/athena-0.png
 tags:
   - ecosystem

--- a/_posts/2026-03-11-nemotron-3-super.md
+++ b/_posts/2026-03-11-nemotron-3-super.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Run Highly Efficient and Accurate Multi-Agent AI with NVIDIA Nemotron 3 Super Using vLLM"
 author: "NVIDIA Nemotron Team"
+summary: "How to serve NVIDIA Nemotron 3 Super with vLLM for multi-agent AI, including BF16, FP8, and NVFP4 checkpoints, 1M-token context, Thinking Budget, MTP, supported GPUs, and OpenAI-compatible deployment."
 image: /assets/figures/2026-nemotron-3-super/figure1.png
 tags:
   - model-support

--- a/_posts/2026-03-13-p-eagle.md
+++ b/_posts/2026-03-13-p-eagle.md
@@ -2,6 +2,7 @@
 layout: post
 title: "P-EAGLE: Faster LLM inference with Parallel Speculative Decoding in vLLM"
 author: "Amazon and NVIDIA Team"
+summary: "How P-EAGLE brings parallel speculative decoding to vLLM by generating multiple draft tokens in one forward pass, with pre-trained drafter heads, config support, and B200 speedups over EAGLE-3."
 image: /assets/figures/2026-03-13-p-eagle/fig1_speedbench_overview.png
 tags:
   - performance

--- a/_posts/2026-03-24-mrv2.md
+++ b/_posts/2026-03-24-mrv2.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Model Runner V2: A Modular and Faster Core for vLLM"
 author: "vLLM Team"
+summary: "How Model Runner V2 reworks vLLM's execution core with modular model logic, GPU-native input preparation, stable persistent batching, async-first scheduling, and no API changes."
 image: /assets/figures/2026-03-24-mrv2/throughput_comparison.png
 tags:
   - performance

--- a/_posts/2026-03-30-extract-hidden-states.md
+++ b/_posts/2026-03-30-extract-hidden-states.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Extracting hidden states from vLLM"
 author: "Fynn Schmitt-Ulms"
+summary: "How vLLM extracts verifier hidden states through dummy draft models and KV Connector APIs for speculative decoding, enabling offline and online Speculators training without patching vLLM internals."
 image: /assets/figures/2026-03-30-extract-hidden-states/design_diagram.png
 tags:
   - speculative-decoding

--- a/_posts/2026-04-02-gemma4.md
+++ b/_posts/2026-04-02-gemma4.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Announcing Gemma 4 on vLLM: Byte for byte, the most capable open models"
 author: "Google Team"
+summary: "How vLLM supports Google's Gemma 4 open models across NVIDIA, AMD, Intel, and TPU backends, with multimodal inputs, agentic workflows, long context, function calling, and deployment recipes."
 image: /assets/figures/gemma4/gemma4-elo-score.png
 tags:
   - model-support

--- a/_posts/2026-04-07-moriio-kv-connector.md
+++ b/_posts/2026-04-07-moriio-kv-connector.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Next-Level Inference: Why Your Single-Node vLLM Setup Needs Prefill-Decode Disaggregation"
 author: "AMD and Embedded LLM"
+summary: "How single-node prefill/decode disaggregation in vLLM uses AMD MORI-IO on an 8-GPU MI300X node to separate prefill and decode, transfer KV cache efficiently, stabilize ITL, and improve goodput."
 image: /assets/figures/2026-04-07-moriio-kv-connector/write-mode-request-flow-diagram.svg
 tags:
   - disaggregation

--- a/_posts/2026-04-14-vllm-korea-meetup-2026.md
+++ b/_posts/2026-04-14-vllm-korea-meetup-2026.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Korea Meetup 2026 Wrap-Up"
 author: "vLLM Team"
+summary: "What the vLLM Korea Meetup 2026 covered: community growth, vLLM V1 updates, production stack adoption, accelerator integration, vllm-playground, and real-world LLM serving."
 image: /assets/figures/vllm-korea-meetup-2026/banner.jpg
 tags:
   - community

--- a/_posts/2026-04-21-hybrid-ssm-disagg.md
+++ b/_posts/2026-04-21-hybrid-ssm-disagg.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Disaggregated Serving for Hybrid SSM Models in vLLM"
 author: "Nicolò Lucchesi, Zhanqiu Hu (Red Hat), and the vLLM team"
+summary: "How vLLM extends NIXL prefill/decode disaggregation to hybrid SSM-attention models with dual descriptor views, physical-logical block bridging, and Mamba conv-state transfer support."
 image: /assets/figures/2026-04-21-hybrid-ssm-disagg/disagg-vs-colocated.png
 tags:
   - disaggregation

--- a/_posts/2026-04-22-fp8-kvcache.md
+++ b/_posts/2026-04-22-fp8-kvcache.md
@@ -2,6 +2,7 @@
 layout: post
 title: "The State of FP8 KV-Cache and Attention Quantization in vLLM"
 author: "Jonas Kübler* (AWS), Eldar Kurtić* (Red Hat AI), Lucas Wilkinson (Red Hat AI), Matthew Bonanni (Red Hat AI), Michael Goin (Red Hat AI), Alexandre Marques (Red Hat AI), Kailash Budhathoki (AWS) (* Equal Contribution)"
+summary: "What vLLM FP8 KV-cache validation found across Hopper and Blackwell, covering attention quantization, Flash Attention 3 fixes, memory savings, decode speedups, and layers to skip."
 image: /assets/figures/2026-04-22-fp8-kvcache/fig1_niah_before_after_plot.png
 tags:
   - quantization

--- a/_posts/2026-04-28-nemotron-omni.md
+++ b/_posts/2026-04-28-nemotron-omni.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Run Highly Efficient Multimodal Agentic AI with NVIDIA Nemotron 3 Nano Omni Using vLLM"
 author: "NVIDIA Nemotron Team"
+summary: "How to serve NVIDIA Nemotron 3 Nano Omni with vLLM for multimodal agentic AI, including BF16, FP8, and NVFP4 checkpoints, vision/audio/video inputs, supported GPUs, OpenAI-compatible APIs, and deployment recipes."
 image: /assets/figures/2026-04-28-nemotron-omni/figure1.png
 tags:
   - model-support

--- a/_posts/2026-05-06-mooncake-store.md
+++ b/_posts/2026-05-06-mooncake-store.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Serving Agentic Workloads at Scale with vLLM x Mooncake"
 author: "Yifan Qiao, Trong Dao Le, Ao Shen, Zhewen Li, Bowen Wang"
+summary: "How vLLM integrates Mooncake Store as a distributed KV cache for agentic workloads, reusing shared prefixes across turns and instances to improve throughput, TTFT, end-to-end latency, and multi-GPU scaling."
 image: /assets/figures/2026-05-06-mooncake-store/hero_vllm_mooncake.svg
 tags:
   - agentic

--- a/_posts/2026-05-11-turboquant.md
+++ b/_posts/2026-05-11-turboquant.md
@@ -2,6 +2,7 @@
 layout: post
 title: "A First Comprehensive Study of TurboQuant: Accuracy and Performance"
 author: "Eldar Kurtić, Michael Goin, Alexandre Marques (Red Hat AI)"
+summary: "A vLLM study comparing TurboQuant KV-cache quantization with BF16 and FP8 across long-context and reasoning workloads, showing where 4-bit variants help, where accuracy drops, and why FP8 remains the default choice."
 image: /assets/figures/2026-05-11-turboquant/llama_70b_pareto.png
 tags:
   - quantization

--- a/_posts/2026-05-11-vllm-tops-artificial-analysis.md
+++ b/_posts/2026-05-11-vllm-tops-artificial-analysis.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Tops the Artificial Analysis Leaderboard"
 author: "vLLM Team"
+summary: "How vLLM achieved leading Artificial Analysis results for DeepSeek V3.2, MiniMax-M2.5, and Qwen 3.5 397B using open-source kernel fusion, speculative decoding, Blackwell optimizations, and model-specific serving work."
 image: /assets/figures/2026-05-11-vllm-tops-artificial-analysis/hero_image.png
 social_image: /assets/figures/2026-05-11-vllm-tops-artificial-analysis/hero_image.png
 read_time_minutes: 15

--- a/_posts/2026-05-14-elastic-expert-parallelism.md
+++ b/_posts/2026-05-14-elastic-expert-parallelism.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Elastic Expert Parallelism in vLLM"
 author: "Itay Alroy (NVIDIA), Yongji Wu (Sky Computing), Rui Qiao (Anyscale), Tyler Michael Smith (Red Hat), Moein Khazraee (NVIDIA), Omri Kahalon (NVIDIA), Tzu-Ling Kan (NVIDIA), Ron Tourgeman (NVIDIA)"
+summary: "How Elastic Expert Parallelism lets vLLM scale Mixture-of-Experts serving up or down at runtime by changing data-parallel workers, redistributing experts, and coordinating live topology changes without server restarts."
 image: /assets/figures/2026-05-14-elastic-expert-parallelism/elastic-ep.png
 tags:
   - large-scale-serving

--- a/_posts/2026-05-14-verl-omni.md
+++ b/_posts/2026-05-14-verl-omni.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Announcing VeRL-Omni: Easy, Fast, and Stable RL Training for Diffusion and Omni-Modality Models"
 author: "VeRL-Omni Team"
+summary: "How VeRL-Omni extends verl with vLLM-Omni for reinforcement learning post-training of diffusion and multimodal generative models, including efficient rollouts, reward inference, trainers, hardware support, and recipes."
 image: /assets/figures/2026-05-14-verl-omni/verl-omni-arch.png
 tags:
   - multimodal

--- a/_posts/2026-05-18-pegaflow.md
+++ b/_posts/2026-05-18-pegaflow.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM x Novita AI: PegaFlow for Production-Grade External KV Cache"
 author: "Novita AI and the vLLM Team"
+summary: "How PegaFlow integrates with vLLM as an external KV cache service, using a Rust daemon, CUDA IPC, RDMA, SSD caching, and the external KV connector to improve startup, sharing, throughput, and cache lifecycle."
 image: /assets/figures/2026-05-18-pegaflow/architecture.png
 tags:
   - kv_cache

--- a/_posts/2026-05-26-eagle-3-1.md
+++ b/_posts/2026-05-26-eagle-3-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: "EAGLE 3.1: Advancing Speculative Decoding Through Collaboration Between the EAGLE Team, vLLM, and TorchSpec"
 author: "EAGLE Team, vLLM Team, and TorchSpec Team"
+summary: "How EAGLE 3.1 improves speculative decoding robustness in vLLM with FC normalization, post-norm hidden-state feedback, TorchSpec training support, and config-driven compatibility with EAGLE 3 checkpoints."
 image: /assets/figures/2026-05-26-eagle-3-1/pre-norm-vs-post-norm.png
 tags:
   - speculative-decoding

--- a/_posts/2026-05-28-laguna-xs2-dflash-llm-compressor.md
+++ b/_posts/2026-05-28-laguna-xs2-dflash-llm-compressor.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Accelerating Laguna XS.2 Inference with vLLM, Speculators, and LLM Compressor"
 author: "Megan Flynn, Dipika Sikka, Alexandre Marques"
+summary: "How Laguna XS.2 is served and optimized in vLLM using first-class model integration, a DFlash speculator trained with Speculators, and FP8, NVFP4, INT4, and INT8 checkpoints from LLM Compressor."
 image: /assets/figures/2026-05-28-laguna-xs2-dflash-llm-compressor/laguna_dflash.png
 tags:
   - quantization

--- a/_posts/2026-05-28-native-rl-apis.md
+++ b/_posts/2026-05-28-native-rl-apis.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Native RL APIs in vLLM"
 author: "Aaron Hao, Sumanth Hegde, Kyle Sayers, Kourosh Hakhamaneshi, and the vLLM team"
+summary: "How vLLM native RL APIs standardize weight syncing and asynchronous RL serving with NCCL and CUDA IPC transfer backends, pause mode, and fixes for fragile DPEP and disaggregated rollout deployments."
 image: /assets/figures/2026-05-28-native-rl-apis/weight_transfer_nccl.svg
 social_image: /assets/figures/2026-05-28-native-rl-apis/weight_transfer_nccl.svg
 read_time_minutes: 12

--- a/_posts/2026-05-28-speculators-v050.md
+++ b/_posts/2026-05-28-speculators-v050.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Speculators v0.5.0: DFlash Support and Online Training"
 author: "Fynn Schmitt-Ulms, Helen Zhao, Rahul Tuli and Dipika Sikka (Red Hat AI Model Optimization Team)"
+summary: "What Speculators v0.5.0 adds for vLLM speculative decoding: DFlash block-diffusion draft models, unified online and offline training, native hidden-state extraction, and Gemma 4 latency results."
 image: /assets/figures/2026-05-28-speculators-v050/gemma4-dflash-acceptance-rates.png
 tags:
   - speculative-decoding

--- a/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
+++ b/_posts/2026-05-28-vllm-sr-vision-encoder-hardening.md
@@ -2,6 +2,7 @@
 layout: post
 title: "From Text to Multimodal Routing: Hardening Vision Signals in vLLM Semantic Router"
 author: "David Shrader, Huamin Chen, Xunzhuo Liu, Bowei He, and the vLLM Semantic Router Team"
+summary: "How vLLM Semantic Router hardens multimodal routing by turning visual evidence into trustworthy signals, debugging a Rust/Candle vision-encoder parity issue, and validating image signal correctness for production policy."
 image: /assets/figures/2026-05-28-vllm-sr-vision-encoder-hardening/hero.png
 tags:
   - ecosystem

--- a/_posts/2026-06-01-vllm-dgx-spark.md
+++ b/_posts/2026-06-01-vllm-dgx-spark.md
@@ -2,10 +2,10 @@
 layout: post
 title: "vLLM on the DGX Spark: Architecture, Configuration, and Local Evaluation"
 author: "Inferact"
+summary: "How to run vLLM on NVIDIA DGX Spark and GB10 systems, including unified memory behavior, NVFP4 Nemotron-3-Super serving, Docker deployment, Prometheus metrics, and local evaluation results."
 image: /assets/figures/2026-05-26-vllm-dgx-spark/office-dgx-spark.jpg
 social_image: /assets/figures/2026-05-26-vllm-dgx-spark/office-dgx-spark.jpg
 read_time_minutes: 16
-summary: "A technical deep dive on running vLLM on NVIDIA DGX Spark and GB10 systems, covering sm_121 architecture, unified memory behavior, NVFP4 model serving, Nemotron-3-Super configuration, Docker deployment, Prometheus metrics, and local evaluation results."
 tags:
   - dgx-spark
   - nemotron

--- a/_posts/2026-06-02-session-aware-agentic-routing.md
+++ b/_posts/2026-06-02-session-aware-agentic-routing.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Session-Aware Agentic Routing: Continuity-Aware Model Selection for Long-Horizon LLM Agents"
 author: "Xunzhuo Liu, Bowei He, Huamin Chen, Haichen Zhang (AMD), Andy Luo (AMD), and the vLLM Semantic Router Team"
+summary: "How Session-Aware Agentic Routing in vLLM Semantic Router preserves long-horizon agent continuity with session memory, safe model-switch boundaries, prefix-cache-aware switch pricing, and replayable traces."
 image: /assets/figures/2026-06-02-session-aware-agentic-routing/hero-v2.png
 social_image: /assets/figures/2026-06-02-session-aware-agentic-routing/hero-v2.png
 read_time_minutes: 14

--- a/_posts/2026-06-02-vllm-omni-autoround.md
+++ b/_posts/2026-06-02-vllm-omni-autoround.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Accelerating vLLM-Omni Inference with AutoRound Quantization"
 author: "vLLM-Omni Community, Intel AutoRound Team"
+summary: "How AutoRound integrates with vLLM-Omni to serve W4A16 quantized multimodal, diffusion, image, and video models with smaller checkpoints, preserved quality, Intel XPU acceleration, and NVIDIA GPU support."
 image: /assets/figures/2026-06-02-vllm-omni-autoround/fig1_omnibench.png
 tags:
   - quantization

--- a/_posts/2026-06-03-deeplearning-ai-vllm-course.md
+++ b/_posts/2026-06-03-deeplearning-ai-vllm-course.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Fast & Efficient LLM Inference with vLLM: A New Course with DeepLearning.AI"
 author: "Cedric Clyburn"
+summary: "What the DeepLearning.AI vLLM course teaches: optimizing, deploying, and benchmarking LLM inference with LLM Compressor quantization, GuideLLM, KV cache sizing, serving, and memory tradeoffs."
 image: /assets/figures/2026-06-03-deeplearning-ai-course/course-banner.png
 tags:
   - community

--- a/_posts/2026-06-04-nemotron-3-ultra-vllm.md
+++ b/_posts/2026-06-04-nemotron-3-ultra-vllm.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Announcing Day-0 Support for NVIDIA Nemotron 3 Ultra on vLLM"
 author: "NVIDIA Nemotron Team"
+summary: "How to serve NVIDIA Nemotron 3 Ultra with vLLM for long-running agentic reasoning, including BF16 and NVFP4 checkpoints, supported GPU configurations, OpenAI-compatible deployment, and NeMo RL integration."
 image: /assets/figures/2026-nemotron-3-ultra/hero.png
 tags:
   - model-support

--- a/_posts/2026-06-05-v0.3-vllm-sr-themis-release.md
+++ b/_posts/2026-06-05-v0.3-vllm-sr-themis-release.md
@@ -2,6 +2,7 @@
 layout: post
 title: "vLLM Semantic Router v0.3 Themis: From Signals to Stateful Production Routing"
 author: "vLLM Semantic Router Team"
+summary: "What vLLM Semantic Router v0.3 Themis adds for production routing: canonical config, inspectable signal-decision-policy flows, safer operations, CLI/dashboard/Kubernetes alignment, and replayable routing behavior."
 image: /assets/figures/2026-06-01-v0.3-vllm-sr-themis-release/hero-v2.png
 social_image: /assets/figures/2026-06-01-v0.3-vllm-sr-themis-release/hero-v2.png
 read_time_minutes: 22

--- a/_posts/2026-06-10-diffusion-gemma.md
+++ b/_posts/2026-06-10-diffusion-gemma.md
@@ -2,8 +2,8 @@
 layout: post
 title: "DiffusionGemma: The First Diffusion LLM (dLLM) Natively Supported in vLLM"
 author: "The vLLM Team and Google DeepMind Team"
+summary: "How vLLM supports DiffusionGemma, the first native diffusion language model in vLLM, using Model Runner V2 state hooks, iterative denoising, bidirectional attention, and reused speculative decoding paths."
 image: /assets/figures/2026-06-10-diffusion-gemma/ar-vs-diffusion.png
-summary: "DiffusionGemma is the first diffusion language model (dLLM) supported in vLLM. We integrated it using model runner v2's ModelState abstraction and reused vLLM's speculative decoding to cleanly demonstrate the flexibility of model runner v2 and how future dLLMs may be supported."
 read_time_minutes: 6
 tags:
   - model

--- a/_posts/2026-06-16-vllm-sr-fusion-api.md
+++ b/_posts/2026-06-16-vllm-sr-fusion-api.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Beyond One Model: Fusion in vLLM Semantic Router"
 author: "vLLM Semantic Router Team"
+summary: "How vLLM Semantic Router Fusion runs a panel of models, uses a judge to analyze agreement and gaps, and synthesizes one answer while preserving routing policy, traces, and OpenAI-compatible serving."
 image: /assets/figures/2026-06-16-vllm-sr-fusion-api/hero-v2.png
 social_image: /assets/figures/2026-06-16-vllm-sr-fusion-api/hero-v2.png
 read_time_minutes: 10


### PR DESCRIPTION
Adds `summary` to 97 blog posts that were missing a summary + updated summaries on 2 blogs (total 99 blogs / 105) to optimize for AI SEO

Spot checks:

| Blog | Added summary |
|---|---|
| [vLLM: Easy, Fast, and Cheap LLM Serving with PagedAttention](https://blog.vllm.ai/2023/06/20/vllm.html) | What the original vLLM launch announced: PagedAttention for KV cache management, up to 24x throughput over Hugging Face Transformers, and lower-cost high-throughput LLM serving. |
| [How Speculative Decoding Boosts vLLM Performance by up to 2.8x](https://blog.vllm.ai/2024/10/17/spec-decode.html) | How speculative decoding works in vLLM, covering EAGLE, Medusa, n-gram proposals, draft and target runners, scheduler and memory-manager changes, and continuous batching for lower token latency. |
| [vLLM V1: A Major Upgrade to vLLM's Core Architecture](https://blog.vllm.ai/2025/01/27/v1-alpha-release.html) | What changed in vLLM V1: a re-architected engine with a simpler scheduler, near-zero-overhead prefix caching, cleaner tensor parallelism, multiprocessing API server, and default optimizations for higher-throughput serving. |
| [Inside vLLM’s New KV Offloading Connector](https://blog.vllm.ai/2026/01/08/kv-offloading-connector.html) | How vLLM's asynchronous KV offloading connector stores KV cache in CPU memory to reduce recomputation, improve throughput under memory pressure, and support pluggable offload backends. |