### PR TITLE
Update Inkling blog PR links and performance highlights

### DIFF
--- a/_posts/2026-07-15-inkling.md
+++ b/_posts/2026-07-15-inkling.md
@@ -20,9 +20,9 @@ We are thrilled to announce that vLLM officially supports the TML Inkling model 
 
 TML Inkling is a 1T-parameter multimodal model trained by [Thinking Machines Lab](https://thinkingmachines.ai/). The model natively accepts **text, image, and audio inputs** and generates text with up to **1M context length**. It introduces several novel architecture components—relative attention, short convolution, and shared expert sinks—all of which are now efficiently integrated into vLLM.
 
-With vLLM, the model runs at up to 380 tok/s/user with MTP and 140 tok/s/user without MTP on 4 GB200 GPUs. vLLM also provides full feature parity, including LoRA, TP/DP/EP/PP parallelism, prefix caching, and disaggregated serving. We verified both model accuracy and tool parsing through comprehensive benchmarks.
+With vLLM, the model runs at up to **380 tok/s/user with MTP** and **140 tok/s/user without MTP** on 4 GB200 GPUs. vLLM also provides full feature parity, including LoRA, TP/DP/EP/PP parallelism, prefix caching, and disaggregated serving. We verified both model accuracy and tool parsing through comprehensive benchmarks.
 
-The integration PR is [available here](). Run the model as follows:
+The integration PR is [available here](https://github.com/vllm-project/vllm/pull/48768). Run the model as follows:
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1
@@ -50,7 +50,7 @@ vLLM provides strong Day-0 support for TML Inkling:
 - **Context length:** up to 1M tokens natively (Tinker exposes 64K and 256K context windows)
 - **Features:** LoRA, speculative decoding (MTP), TP/DP/EP/PP, prefix caching, disaggregated serving, and more
 - **Optimizations:** Sconv-aware TP sharding, low-latency fused collectives, kernel fusion, multi-streaming, PDL, and more
-- **Performance:** Up to 380 tok/s/user (w/ MTP) and 140 tok/s/user (w/o MTP) on 4 GB200 GPUs
+- **Performance:** Up to **380 tok/s/user (w/ MTP)** and **140 tok/s/user (w/o MTP)** on 4 GB200 GPUs
 - **Accuracy:** Model quality and tool parsing verified with MMAU, MMMU-Pro, BFCL, NIAH-1M, and HLE
 
 ## Model Architecture
@@ -91,13 +91,13 @@ vLLM implements the model efficiently through a series of optimizations. Key hig
 
 To eliminate this replication, vLLM shards the model differently. Since sconv operates independently along the channel dimension, we shard sconv across channels: instead of an all-reduce, we use a reduce-scatter and all-gather over the channel dimension. Each GPU then stores only a shard of the sconv cache and computes only its own slice of channels. The idea is similar to sequence parallelism, but sharding is applied to the channel dimension rather than the token dimension.
 
-**Low-latency fused collectives.** vLLM further implements several fused kernels to optimize this new sharding scheme. In particular, we built low-latency reduce-scatter and all-gather kernels (fused with surrounding ops) by extending the Lamport-protocol design of FlashInfer's low-latency all-reduce kernel. The Lamport protocol lets the kernel synchronize via data-value polling instead of explicit barriers, cutting kernel time at batch size 1 from 40 µs to 8 µs (5x).
+**Low-latency fused collectives.** vLLM further implements several fused kernels to optimize this new sharding scheme. In particular, we built low-latency reduce-scatter and all-gather kernels (fused with surrounding ops) by extending the Lamport-protocol design of FlashInfer's low-latency all-reduce kernel. The Lamport protocol lets the kernel synchronize via data-value polling instead of explicit barriers, cutting kernel time at batch size 1 from **40 µs to 8 µs (5x)**.
 
 **FA4 with sheared bias.** Relative attention complicates the memory access pattern, significantly slowing down the attention kernel's compute pipeline. To overcome this, TML released a new FA4 kernel with a sheared-bias technique, which vLLM integrates directly. vLLM additionally selects FA4's `num_splits` factor per configuration—accounting for batch size, TP size, and KV length—to maximize performance.
 
 **Re-computing MTP KV cache.** Because each MTP head takes the previous head's draft token as input, its KV cache becomes stale whenever a draft token is rejected. vLLM handles this carefully: it caches the base model's hidden states for the last few tokens and re-runs the MTP heads with the accepted tokens after rejection sampling.
 
-Beyond these, vLLM's model implementation includes additional kernel fusion, PDL, and multi-streaming to achieve speed-of-light performance. For details, please check out our PR.
+Beyond these, vLLM's model implementation includes additional kernel fusion, PDL, and multi-streaming to achieve speed-of-light performance. For details, please check out [our PR](https://github.com/vllm-project/vllm/pull/48768).
 
 ### Performance
 


### PR DESCRIPTION
## Summary

- link the Inkling integration references to vllm-project/vllm#48768
- add the PR link to the detailed optimization discussion
- bold the throughput and kernel-latency performance figures for easier scanning

## Impact

Readers can now navigate directly to the implementation PR from both references, and the post's key performance results are easier to identify.

## Validation

- `git diff --check`
- verified both PR links point to `https://github.com/vllm-project/vllm/pull/48768`
- Jekyll build not run: Ruby and Bundler are unavailable in the local environment