### PR TITLE
Fix Inkling model name casing

### DIFF
--- a/_posts/2026-07-15-inkling.md
+++ b/_posts/2026-07-15-inkling.md
@@ -28,7 +28,7 @@ The integration PR is [available here](https://github.com/vllm-project/vllm/pull
 export VLLM_USE_V2_MODEL_RUNNER=1
 export FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1
 
-vllm serve thinkingmachines/inkling-nvfp4 \
+vllm serve thinkingmachines/Inkling-NVFP4 \
       --tokenizer-mode inkling \
       --reasoning-parser inkling \
       --tool-call-parser inkling \
@@ -71,7 +71,7 @@ A distinctive design choice in Inkling is *relative attention* as its positional
 
 **MoE.** Each layer has 256 routed experts (top-6) plus 2 shared experts, so every token is processed by 8 experts in total. Unlike existing models, however, Inkling introduces the concept of an *expert sink*: the two shared experts participate in the routing-score computation (absorbing probability mass) but are excluded as candidates from the top-6 selection.
 
-In `thinkingmachines/inkling-nvfp4`, only the routed experts are quantized to NVFP4; all other parameters, including the shared experts and the qkvr linears, remain in BF16. In `thinkingmachines/inkling`, the MoE weights are in BF16 as well.
+In `thinkingmachines/Inkling-NVFP4`, only the routed experts are quantized to NVFP4; all other parameters, including the shared experts and the qkvr linears, remain in BF16. In `thinkingmachines/Inkling`, the MoE weights are in BF16 as well.
 
 **MTP.** Inkling ships with **8 MTP heads** for speculative decoding, allowing the model to generate up to 9 tokens per forward step. The MTP heads are *chained*: each head consumes the hidden states and sampled draft token from the previous head. Each MTP head is a single-layer Transformer with full or sliding window attention and a dense MLP. All MTP weights are in BF16.
 


### PR DESCRIPTION
## Summary

- Correct the Inkling NVFP4 model identifier in the serving example.
- Correct both Inkling model identifiers in the architecture description.

## Why

The post used lowercase model names in two places, while the canonical Hugging Face repository names use `Inkling-NVFP4` and `Inkling`. Matching the canonical casing prevents copy-paste errors in case-sensitive model identifiers.

## Impact

Readers can copy the documented model names directly and consistently.

## Validation

- `git diff --check main...HEAD`
- Verified no lowercase `thinkingmachines/inkling` identifiers remain in the post.