### PR TITLE
blog: align Mixture-of-Models post framing

### DIFF
--- a/_posts/2026-07-21-vllm-sr-new-chapter-mom.md
+++ b/_posts/2026-07-21-vllm-sr-new-chapter-mom.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: "The Next Model Is a System: Building the Mixture-of-Models Era"
+title: "Beyond a Single Model: Building Mixture-of-Models Systems with vLLM Semantic Router"
 author: "vLLM Semantic Router Team"
-summary: "At 5,000 GitHub stars, vLLM Semantic Router begins a new chapter: building the training, evaluation, and inference engine for Mixture-of-Models."
+summary: "vLLM Semantic Router is expanding from intelligent routing into a system for building, evaluating, and running Mixture-of-Models."
 image: /assets/figures/2026-07-21-vllm-sr-new-chapter/banner.png
 social_image: /assets/figures/2026-07-21-vllm-sr-new-chapter/banner.png
 read_time_minutes: 15
@@ -12,11 +12,11 @@ tags:
   - semantic-router
 ---
 
-vLLM Semantic Router is taking on a larger problem: how can intelligence distributed across models, devices, and environments be trained, evaluated, and run as one model? We call this architecture **Mixture-of-Models**.
+Most AI applications are built around a single model endpoint. But as models, devices, and deployment constraints diversify, no single model is the best fit for every request or environment. The practical question is how multiple specialized models can be coordinated, evaluated, and served through one interface. We call this systems approach **Mixture-of-Models**.
 
 In less than a year since its public launch, [vLLM Semantic Router](https://github.com/vllm-project/semantic-router) has reached **5,000 stars**, **150+ contributors**, and **more than 300,000 cumulative downloads** across our Hugging Face model family. Across three major releases—**Iris, Athena, and Themis**—the system boundary moved from choosing a model, to governing multi-model inference, to preserving state and coordination across sessions. Those releases built the foundation for the MoM architecture envisioned from day 0.
 
-Now we are moving the boundary again: from routing among models to building a model out of them. Under one versioned contract, independent models, policies, preferences, and execution paths become a system that can be trained, evaluated, exported, imported, deployed, and invoked as one model. **vLLM Semantic Router is becoming the training, evaluation, and inference engine for Mixture-of-Models—so many models can feel like one.**
+This post describes the next step for vLLM Semantic Router: moving from routing among models to building dependable model systems from them. Under one versioned contract, independent models, policies, preferences, and execution paths become a system that can be trained, evaluated, exported, imported, deployed, and invoked through one interface. Our goal is to make vLLM Semantic Router a training, evaluation, and inference engine for Mixture-of-Models.
 
 <p align="center">
   <img src="/assets/figures/2026-07-21-vllm-sr-new-chapter/hero.png" alt="A model portfolio flows into a Mixture-of-Models training, evaluation, and inference engine and is exposed as one model" width="100%">
@@ -312,8 +312,8 @@ At this milestone, the project stands at **1,734 commits** and **150+ contributo
 
 Join us on [GitHub](https://github.com/vllm-project/semantic-router), explore the [documentation](https://vllm-sr.ai), try the [MoM model family](https://huggingface.co/LLM-Semantic-Router), and meet the community in the `#semantic-router` channel on [vLLM Slack](https://vllm-dev.slack.com/archives/C09CTGF8KCN).
 
-The first chapter taught infrastructure how to choose a model.
+vLLM Semantic Router began by helping infrastructure choose the right model for each request.
 
-The next builds the model itself as a system—across models, devices, and environments.
+Now we are extending that foundation beyond a single model: toward systems that can coordinate, evaluate, and operate multiple models across devices and environments.
 
-**Welcome to the Mixture-of-Models era.**
+We invite the community to help build and test that approach in the open.


### PR DESCRIPTION
## Summary

- update the post title to "Beyond a Single Model: Building Mixture-of-Models Systems with vLLM Semantic Router"
- align the SEO summary and opening with the practical motivation for multi-model systems
- revise the closing to connect back to the title and remove the broader "Mixture-of-Models era" framing

## Why

This is an editorial follow-up to #275. The revised framing is more focused and keeps the beginning and ending consistent with the new title.

## Impact

Editorial only. The post content, figures, links, and site behavior are otherwise unchanged.

## Validation

- parsed the YAML front matter successfully
- confirmed the summary remains under the 240-character limit
- ran `git diff --check`
