### PR TITLE
Correct GPU references from GB300 to NVL72

### DIFF
--- a/_posts/2026-07-27-k3.md
+++ b/_posts/2026-07-27-k3.md
@@ -49,7 +49,7 @@ For more details, including Docker images for various platforms and deployment s
 ## TL;DR
 
 - **A 2.8-trillion-parameter multimodal MoE:** Kimi K3 activates 16 of 896 experts per token, supports a context window of up to 1M tokens, and is built on Kimi Delta Attention, Attention Residuals, LatentMoE, and native MXFP4 (4-bit) weights.
-- **Up to 370 tok/s per user:** vLLM serves Kimi K3 at 118 tok/s without speculative decoding and 370 tok/s (a 3.14× improvement) with DSpark on 16 NVIDIA GB300 GPUs, powered by extensive optimizations for Kimi K3's architecture.
+- **Up to 370 tok/s per user:** vLLM serves Kimi K3 at 118 tok/s without speculative decoding and 370 tok/s (a 3.14× improvement) with DSpark on 16 NVIDIA GB300 NVL72 GPUs, powered by extensive optimizations for Kimi K3's architecture.
 - **Broad production feature support:** vLLM supports speculative decoding, prefill/decode disaggregation, agentic KV caching with Mooncake, tool calling, reasoning output, and structured output, with NVIDIA (Hopper and Blackwell) and AMD (MI355X) support at launch.
 - **Open-source DSpark support:** vLLM supports the state-of-the-art block-diffusion speculative decoding algorithm for Kimi K3, trained with vLLM and TorchSpec and open-sourced by Inferact.
 - **Hybrid prefix caching:** serving Kimi K3's recurrent and full-attention design required a redesign of hybrid prefix caching over recurrent KDA state. This change now benefits every hybrid linear model.
@@ -197,7 +197,7 @@ Together, the policies cover both predictable and emergent reuse: interval reten
 
 ## Performance optimizations
 
-Serving large models like Kimi K3 brings its own challenges because of its size. The entire model can barely fit in a single B300 DGX node and requires a minimum of 16 NVIDIA B200/GB200 GPUs to serve on that hardware generation. Serving must trade off interactivity against total system throughput: tensor parallelism is good for interactivity but offers low overall throughput because effective KV cache size is limited, while large-scale expert parallelism can limit per-user output-token speed because of network-bandwidth bottlenecks. Here we highlight optimizations that improve performance in both cases so users can choose the recipe that suits their workload. Many of these optimizations are already covered in our [preview blog](https://vllm.ai/blog/2026-07-22-kimi-k3-preview).
+Serving large models like Kimi K3 brings its own challenges because of its size. The entire model can barely fit in a single NVIDIA DGX B300 and requires a minimum of 16 NVIDIA B200/GB200 GPUs to serve on that hardware generation. Serving must trade off interactivity against total system throughput: tensor parallelism is good for interactivity but offers low overall throughput because effective KV cache size is limited, while large-scale expert parallelism can limit per-user output-token speed because of network-bandwidth bottlenecks. Here we highlight optimizations that improve performance in both cases so users can choose the recipe that suits their workload. Many of these optimizations are already covered in our [preview blog](https://vllm.ai/blog/2026-07-22-kimi-k3-preview).
 
 ### Attention Residuals
 
@@ -213,7 +213,7 @@ A KDA layer involves many operations: input projections, causal 1D convolutions,
 
 ### KDA prefill
 
-KDA prefill became one of our favorite examples of open-source development in practice. Moonshot AI first released [FlashKDA](https://github.com/MoonshotAI/FlashKDA), a high-performance CUTLASS implementation of KDA. We quickly integrated it into vLLM and worked through less glamorous production details: broader GPU coverage, metadata dtypes, tensor layouts, and reliable vendoring. [Shikhar Mishra](https://github.com/Itssshikhar) then optimized the kernels for H100 and published [Flash-Flash-KDA](https://github.com/Itssshikhar/Flash-Flash-KDA), improving data movement while preserving numerical correctness. Within a day, we validated the improvements on GB300, refined the recurrence pipeline and synchronization, and folded them into our FlashKDA integration. The result was not a one-way handoff, but a continuous loop in which an open kernel was extended by the serving community, improved by an independent contributor, and quickly carried into production.
+KDA prefill became one of our favorite examples of open-source development in practice. Moonshot AI first released [FlashKDA](https://github.com/MoonshotAI/FlashKDA), a high-performance CUTLASS implementation of KDA. We quickly integrated it into vLLM and worked through less glamorous production details: broader GPU coverage, metadata dtypes, tensor layouts, and reliable vendoring. [Shikhar Mishra](https://github.com/Itssshikhar) then optimized the kernels for H100 and published [Flash-Flash-KDA](https://github.com/Itssshikhar/Flash-Flash-KDA), improving data movement while preserving numerical correctness. Within a day, we validated the improvements on GB300 NVL72, refined the recurrence pipeline and synchronization, and folded them into our FlashKDA integration. The result was not a one-way handoff, but a continuous loop in which an open kernel was extended by the serving community, improved by an independent contributor, and quickly carried into production.
 
 ### KDA metadata builder
 
@@ -247,11 +247,11 @@ One caveat worth knowing for evaluation: Kimi K3 thinks a lot before it answers.
 
 ![Kimi K3 single-user decode throughput](/assets/figures/2026-07-27-k3/serving-performance.png)
 
-_Kimi K3 decode throughput at batch size 1, measured on GB300 GPUs in TP8 and TP16 configurations._
+_Kimi K3 decode throughput at batch size 1, measured on GB300 NVL72 GPUs in TP8 and TP16 configurations._
 
 At launch, vLLM achieves 111 tok/s per user on TP8 and 118 tok/s per user on TP16 at batch size 1. DSpark speculative decoding boosts interactivity by roughly 3×, reaching 331 tok/s per user on TP8 and 370 tok/s per user on TP16.
 
-![Kimi K3 GB300 pareto curve](/assets/figures/2026-07-27-k3/pareto-gb300.png)
+![Kimi K3 GB300 NVL72 pareto curve](/assets/figures/2026-07-27-k3/pareto-gb300.png)
 
 
 ### Reproduce our benchmark
@@ -333,7 +333,7 @@ Full recipes, including multi-node, expert-parallel, and vision configurations, 
 
 ### How many GPUs do I need to serve Kimi K3?
 
-At least one 8× B300 (or GB300) node is required; 16× B200 is also supported. Most production deployments run multi-node with expert and data parallelism, connected over RDMA or NVLink.
+At least one 8× B300 (or GB300 NVL72) node is required; 16× B200 is also supported. Most production deployments run multi-node with expert and data parallelism, connected over RDMA or NVLink.
 
 ### How do I enable DSpark speculative decoding?
 


### PR DESCRIPTION
Updated references from NVIDIA GB300 to NVIDIA NVL72 GPUs throughout the document for accuracy.