### PR TITLE
Qwen35 25k tok images fix

### DIFF
--- a/_posts/2026-08-06-qwen35-25k-tps.md
+++ b/_posts/2026-08-06-qwen35-25k-tps.md
@@ -87,17 +87,13 @@ For performance measurements we used a fixed input sequence length / output sequ
 
 Pareto curves for the individual configurations are shown in [Figure 1](#figure-1), and the final Pareto frontier obtained after combining all configurations is shown in [Figure 2](#figure-2). Total TPS per GPU reaches **25,000** tokens per second. Concurrency was swept from 64 up to 5120. We did not measure low concurrencies in the range of 1 to 32, since our focus here was the left part of the Pareto curve — maximizing the total TPS per GPU metric. At the other end, we did not go beyond 5120 because that is where we started running out of KV cache capacity on the decode side, which we deliberately fixed at a single 8×GB200 endpoint throughout these measurements. Pushing concurrency higher is entirely possible, but it requires adding GPUs on the decode side.
 
-<p align="center" id="figure-1">
-<img src="/assets/figures/2026-08-06-qwen35-25k-tps/pareto-curves-by-prefill-endpoints.png" width="100%">
-<br>
-<em>Figure 1: Pareto curves for disaggregated Qwen3.5 serving with different numbers of prefill instances.</em>
-</p>
+<span id="figure-1"></span>
 
-<p align="center" id="figure-2">
-<img src="/assets/figures/2026-08-06-qwen35-25k-tps/pareto-frontier-qwen35-nvfp4.png" width="100%">
-<br>
-<em>Figure 2: Final Pareto frontier for disaggregated serving of Qwen3.5 NVFP4 in vLLM.</em>
-</p>
+![Figure 1: Pareto curves for disaggregated Qwen3.5 serving with different numbers of prefill instances.](/assets/figures/2026-08-06-qwen35-25k-tps/pareto-curves-by-prefill-endpoints.png)
+
+<span id="figure-2"></span>
+
+![Figure 2: Final Pareto frontier for disaggregated serving of Qwen3.5 NVFP4 in vLLM.](/assets/figures/2026-08-06-qwen35-25k-tps/pareto-frontier-qwen35-nvfp4.png)
 
 ## Recipes & best practices
 


### PR DESCRIPTION
On a new blog post "vLLM Reaches 25K Total TPS/GPU on Qwen3.5" images do not render properly due to wrong markup in the source file. Replaced html to md for inserting images. Tested locally using `bundle`.

<img width="1280" height="650" alt="image" src="https://github.com/user-attachments/assets/000a6dad-9d00-49a0-9ec6-5fdd9e321455" />
